### PR TITLE
Set service.name through sdk::Resource

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,13 +286,12 @@ impl<C> PipelineBuilder<C> {
     ///     .install_simple();
     /// ```
     pub fn with_trace_config(self, config: sdk::trace::Config) -> Self {
-        let base_config = match self.config {
-            Some(base_config) => base_config,
-            None => config,
+        let merged_resource = match self.config {
+            Some(base_config) => base_config.resource.merge(&config.resource),
+            None => (*config.resource).clone(),
         };
 
-        let merged_resource = base_config.resource.merge(&config.resource);
-        config.with_resource(merged_resource);
+        let config = config.with_resource(merged_resource);
 
         PipelineBuilder {
             config: Some(config),
@@ -314,7 +313,7 @@ impl<C> PipelineBuilder<C> {
     ///     .with_service_name("my-application")
     ///     .install_simple();
     /// ```
-    pub fn with_service_name<T: Into<String>>(mut self, name: T) -> Self {
+    pub fn with_service_name<T: Into<String>>(self, name: T) -> Self {
         let config = match self.config {
             Some(config) => config,
             None => sdk::trace::Config::default(),
@@ -326,7 +325,7 @@ impl<C> PipelineBuilder<C> {
                 "service.name",
                 name.into(),
             )]));
-        config.with_resource(merged_resource);
+        let config = config.with_resource(merged_resource);
 
         PipelineBuilder {
             config: Some(config),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,7 +315,6 @@ impl<C> PipelineBuilder<C> {
     ///     .install_simple();
     /// ```
     pub fn with_service_name<T: Into<String>>(mut self, name: T) -> Self {
-        self.service_name = name.into();
 
         let config = match self.config {
             Some(config) => config,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,7 +324,7 @@ impl<C> PipelineBuilder<C> {
             .resource
             .merge(&sdk::Resource::new(vec![KeyValue::new(
                 "service.name",
-                name,
+                name.into(),
             )]));
         config.with_resource(merged_resource);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@ use opentelemetry::{
         },
     },
     trace::{Event, SpanKind, StatusCode, TracerProvider},
-    Key, Value,
+    Key, KeyValue, Value,
 };
 use opentelemetry_semantic_conventions as semcov;
 use std::collections::HashMap;
@@ -291,7 +291,7 @@ impl<C> PipelineBuilder<C> {
             None => config,
         };
 
-        let merged_resource = base_config.resource.merge(config.resource);
+        let merged_resource = base_config.resource.merge(&config.resource);
         config.with_resource(merged_resource);
 
         PipelineBuilder {
@@ -315,16 +315,17 @@ impl<C> PipelineBuilder<C> {
     ///     .install_simple();
     /// ```
     pub fn with_service_name<T: Into<String>>(mut self, name: T) -> Self {
-
         let config = match self.config {
             Some(config) => config,
             None => sdk::trace::Config::default(),
         };
 
-        let merged_resource = config.resource.merge(sdk::Resource::new(vec![KeyValue::new(
-            "service.name",
-            name,
-        )]));
+        let merged_resource = config
+            .resource
+            .merge(&sdk::Resource::new(vec![KeyValue::new(
+                "service.name",
+                name,
+            )]));
         config.with_resource(merged_resource);
 
         PipelineBuilder {


### PR DESCRIPTION
Rather than relying on a property on PipelineBuilder, instead set the
service.name in the sdk::Config by merging sdk::Resouce properties. This
is also a change to the behavior of with_config.